### PR TITLE
be explicit about where whitespace is allowed

### DIFF
--- a/d20/dice.py
+++ b/d20/dice.py
@@ -10,7 +10,7 @@ from .stringifiers import MarkdownStringifier
 
 __all__ = ("CritType", "AdvType", "RollContext", "RollResult", "Roller")
 
-POSSIBLE_COMMENT_AMBIGUITIES = {"k", "p", "rr", "ro", "ra", "e", "mi", "ma", "*", "d"}
+POSSIBLE_COMMENT_AMBIGUITIES = {"*", }
 
 
 class CritType(IntEnum):

--- a/d20/diceast.py
+++ b/d20/diceast.py
@@ -182,7 +182,7 @@ class AnnotatedNumber(Node):  # numexpr
         """
         super().__init__()
         self.value = value
-        self.annotations = [str(a) for a in annotations]
+        self.annotations = [str(a).strip() for a in annotations]
 
     @property
     def children(self):

--- a/d20/grammar.lark
+++ b/d20/grammar.lark
@@ -5,27 +5,27 @@ commented_expr: num COMMENT?
 // ^ starting node for commented rolls
 
 // comments are given -1 priority - only match comment if no other possibilities
-COMMENT.-1: /.+/
+COMMENT.-1: _WS? /.+/
 
 // math and operators, PMDAS
 ?num: comparison
 
-?comparison: (comparison COMP_OPERATOR)? a_num
+?comparison: (comparison COMP_OPERATOR _WS?)? a_num _WS?
 COMP_OPERATOR: "==" | ">=" | "<=" | "!=" | "<" | ">"
 
-?a_num: (a_num A_OP)? m_num
+?a_num: (a_num A_OP _WS?)? m_num _WS?
 A_OP: "+" | "-"
 
-?m_num: (m_num M_OP)? u_num
+?m_num: (m_num M_OP _WS?)? u_num _WS?
 M_OP: "*" | "//" | "/" | "%"
 
-?u_num: numexpr | U_OP u_num
+?u_num: numexpr | U_OP _WS? u_num
 U_OP: "+" | "-"
 
 // numbers
-?numexpr: (dice | set | literal) ANNOTATION*
+?numexpr: (dice | set | literal) _WS? ANNOTATION*
 
-ANNOTATION: /\[.*?\]/
+ANNOTATION: /\[.*?\]/ _WS?
 
 literal: INTEGER | DECIMAL
 
@@ -35,7 +35,7 @@ literal: INTEGER | DECIMAL
 set_op: SET_OPERATOR selector
 SET_OPERATOR: "k" | "p"
 
-setexpr: "(" (num ("," num)* comma?)? ")"
+setexpr: "(" _WS? (num (_WS? "," _WS? num)* _WS? comma? _WS?)? _WS? ")"
 comma: ","
 
 // dice
@@ -50,8 +50,9 @@ selector: [SELTYPE] INTEGER
 
 SELTYPE: "l" | "h" | "<" | ">"
 
+// whitespace
+_WS: /[ \t\f\r\n]/+
+
 // useful constants
-%import common.WS_INLINE
 %import common.INT -> INTEGER
 %import common.DECIMAL
-%ignore WS_INLINE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cachetools>=3.1.0
-lark-parser~=0.8.0
+lark-parser~=0.9.0

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -36,6 +36,13 @@ def test_conflicting_comments():
     with pytest.raises(RollSyntaxError):
         roll("1d20 **bold**", allow_comments=False)
 
+    r = roll("1d20 please save me from this parsing weirdness", allow_comments=True)
+    assert 1 <= r.total <= 20
+    assert r.comment == "please save me from this parsing weirdness"
+
+    with pytest.raises(RollSyntaxError):
+        roll("1d20 please save me from this parsing weirdness", allow_comments=False)
+
 
 def test_advantage():
     r = roll("1d20", advantage=AdvType.ADV)


### PR DESCRIPTION
- Fixes avrae/avrae#1148
- Bumps lark-parser to 0.9.0

This introduces a slight overhead in parsing (5us-300us depending on the size of the expression):

`python3 -m timeit -s "from d20 import parse; expr='1d20 + '*50+'1d20'" "parse(expr, True)"`

Before: 1.52ms
After: 1.84ms

`python3 -m timeit -s "from d20 import parse; expr='1d20 dont break'" "parse(expr, True)"`

Before: 39.4us
After: 44.3us

But these are mostly negated by caching:

`python3 -m timeit -s "from d20 import roll; expr='1d20 + '*50+'1d20'" "roll(expr)"`

Before: 310us
After: 323us