### PR TITLE
Add support for percentile dice (Nd%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ This is the grammar supported by the dice parser, roughly ordered in how tightly
 ### Numbers
 These are the atoms used at the base of the syntax tree.
 
-| Name    | Syntax                           | Description           | Examples                       |
-|---------|----------------------------------|-----------------------|--------------------------------|
-| literal | `INT`, `DECIMAL`                 | A literal number.     | `1`, `0.5`, `3.14`             |
-| dice    | `INT? "d" (INT | "%")`           | A set of die.         | `d20`, `3d6`                   |
-| set     | `"(" (num ("," num)* ","?)? ")"` | A set of expressions. | `()`, `(2,)`, `(1, 3+3, 1d20)` |
+| Name    | Syntax                            | Description           | Examples                       |
+|---------|-----------------------------------|-----------------------|--------------------------------|
+| literal | `INT`, `DECIMAL`                  | A literal number.     | `1`, `0.5`, `3.14`             |
+| dice    | `INT? "d" (INT \| "%")`           | A set of die.         | `d20`, `3d6`                   |
+| set     | `"(" (num ("," num)* ","?)? ")"`  | A set of expressions. | `()`, `(2,)`, `(1, 3+3, 1d20)` |
 
 Note that `(3d6)` is equivalent to `3d6`, but `(3d6,)` is the set containing the one element `3d6`.
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ This is the grammar supported by the dice parser, roughly ordered in how tightly
 ### Numbers
 These are the atoms used at the base of the syntax tree.
 
-| Name    | Syntax            | Description       | Examples           |
-|---------|-------------------|-------------------|--------------------|
-| literal | `INT`, `DECIMAL`  | A literal number. | `1`, `0.5`, `3.14` |
-| dice    | `INT? "d" INT`    | A set of die.     | `d20`, `3d6`       |
+| Name    | Syntax                           | Description           | Examples                       |
+|---------|----------------------------------|-----------------------|--------------------------------|
+| literal | `INT`, `DECIMAL`                 | A literal number.     | `1`, `0.5`, `3.14`             |
+| dice    | `INT? "d" (INT | "%")`           | A set of die.         | `d20`, `3d6`                   |
 | set     | `"(" (num ("," num)* ","?)? ")"` | A set of expressions. | `()`, `(2,)`, `(1, 3+3, 1d20)` |
 
 Note that `(3d6)` is equivalent to `3d6`, but `(3d6,)` is the set containing the one element `3d6`.

--- a/d20/diceast.py
+++ b/d20/diceast.py
@@ -55,9 +55,16 @@ class RollTransformer(Transformer):
         return SetOperator.new(*opsel)
 
     def diceexpr(self, dice):
-        if len(dice) == 1:
-            return Dice(1, *dice)
-        return Dice(*dice)
+        reduced_dice = []
+        for token in dice:
+            if isinstance(token, Token):
+                reduced_dice.append(token)
+            else:
+                reduced_dice.append(token.children[0])
+
+        if len(reduced_dice) == 1:
+            return Dice(1, *reduced_dice)
+        return Dice(*reduced_dice)
 
     def selector(self, sel):
         return SetSelector(*sel)
@@ -420,7 +427,10 @@ class Dice(Node):  # diceexpr
         """
         super().__init__()
         self.num = int(num)
-        self.size = int(size)
+        if size.value == "%":
+            self.size = size.value
+        else:
+            self.size = int(size)
 
     @property
     def children(self):

--- a/d20/expression.py
+++ b/d20/expression.py
@@ -331,7 +331,7 @@ class Dice(Set):
     def __init__(self, num, size, values, operations=None, context=None, **kwargs):
         """
         :type num: int
-        :type size: int
+        :type size: int|str
         :type values: list of Die
         :type operations: list[SetOperator]
         :type context: dice.RollContext
@@ -390,11 +390,14 @@ class Die(Number):  # part of diceexpr
         return []
 
     def _add_roll(self):
-        if self.size < 1:
+        if self.size != '%' and self.size < 1:
             raise errors.RollValueError("Cannot roll a 0-sided die.")
         if self._context:
             self._context.count_roll()
-        n = Literal(random.randrange(self.size) + 1)  # 200ns faster than randint(1, self._size)
+        if self.size == '%':
+            n = Literal(random.randrange(0, 100, 10))
+        else:
+            n = Literal(random.randrange(self.size) + 1)  # 200ns faster than randint(1, self._size)
         self.values.append(n)
 
     def reroll(self):

--- a/d20/grammar.lark
+++ b/d20/grammar.lark
@@ -44,7 +44,9 @@ comma: ","
 dice_op: (DICE_OPERATOR | SET_OPERATOR) selector
 DICE_OPERATOR: "rr" | "ro" | "ra" | "e" | "mi" | "ma"
 
-diceexpr: INTEGER? "d" INTEGER
+diceexpr: INTEGER? "d" DICE_VALUE
+
+DICE_VALUE: INTEGER | "%"
 
 selector: [SELTYPE] INTEGER
 

--- a/tests/test_dice.py
+++ b/tests/test_dice.py
@@ -3,7 +3,7 @@ import pytest
 from d20 import *
 
 STANDARD_EXPRESSIONS = [
-    '1d20', '1+1', '4d6kh3', '(1)', '(1,)', '((1d6))', '4*(3d8kh2+9[fire]+(9d2e2+3[cold])/2)',
+    '1d20', '1d%', '1+1', '4d6kh3', '(1)', '(1,)', '((1d6))', '4*(3d8kh2+9[fire]+(9d2e2+3[cold])/2)',
     '(1d4, 2+2, 3d6kl1)kh1', '((10d6kh5)kl2)kh1'
 ]
 
@@ -29,11 +29,14 @@ def test_roll_types():
 
 
 def test_sane_totals():
-    assert 1 <= r("1d20") <= 20
-    assert 3 <= r("4d6kh3") <= 18
-    assert 1 <= r("(((1d6)))") <= 6
-    assert 4 <= r("(1d4, 2+2, 3d6kl1)kh1") <= 6
-    assert 1 <= r("((10d6kh5)kl2)kh1") <= 6
+    for _ in range(1000):
+        assert 1 <= r("1d20") <= 20
+        assert 0 <= r("1d%") <= 90
+        assert 0 <= r("1d%") % 10 <= 9
+        assert 3 <= r("4d6kh3") <= 18
+        assert 1 <= r("(((1d6)))") <= 6
+        assert 4 <= r("(1d4, 2+2, 3d6kl1)kh1") <= 6
+        assert 1 <= r("((10d6kh5)kl2)kh1") <= 6
 
 
 def test_pemdas():
@@ -84,10 +87,15 @@ def test_literal():
 
 
 def test_dice():
-    assert r("0d6") == 0
-    assert 1 <= r("d6") <= 6
-    assert 1 <= r("1d6") <= 6
-    assert 2 <= r("2d6") <= 12
+    for _ in range(1000):
+        assert r("0d6") == 0
+        assert 1 <= r("d6") <= 6
+        assert 1 <= r("1d6") <= 6
+        assert 2 <= r("2d6") <= 12
+        assert r("0d%") == 0
+        assert 0 <= r("d%") <= 90
+        assert 0 <= r("1d%") <= 90
+        assert 0 <= r("2d%") <= 180
 
 
 def test_set():
@@ -110,6 +118,16 @@ def test_binop():
     assert r("15 / 2") == 7
     assert r("15 // 2") == 7
     assert r("13 % 2") == 1
+
+
+def test_binop_dice():
+    for _ in range(1000):
+        assert 3 <= r("2 + 1d6") <= 8
+        assert 2 <= r("2 * 1d6") <= 12
+        assert r("60 / 1d6") in [60, 30, 20, 15, 12, 10]
+        assert r("60 // 1d6") in [60, 30, 20, 15, 12, 10]
+        assert r("1d100 % 10") <= 10
+        assert r("1d% % 10") <= 10
 
 
 def test_div_zero():


### PR DESCRIPTION
### Summary
Percentile dice are used in various games which use dice (including other RPGs). This PR adds support for them. Adding support makes the d20 library more flexible and useful for these games.

Examples of usage: `d%`, `1d%`, `10d%`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
