### PR TITLE
Use `random.randrange(10) * 10` for percentile dice

### DIFF
--- a/d20/expression.py
+++ b/d20/expression.py
@@ -402,7 +402,7 @@ class Die(Number):  # part of diceexpr
         if self._context:
             self._context.count_roll()
         if self.size == '%':
-            n = Literal(random.randrange(0, 100, 10))
+            n = Literal(random.randrange(10) * 10)  # faster than random.randrange(0, 100, 10)
         else:
             n = Literal(random.randrange(self.size) + 1)  # 200ns faster than randint(1, self._size)
         self.values.append(n)


### PR DESCRIPTION
### Summary
In the following benchmark `random.randrange(10) * 10` seems to be about 30% faster in python3.8 on my machine:
```py
import timeit


if __name__ == '__main__':
    for line in [
        'randrange(0, 100, 10)',
        'randrange(10) * 10',
        'randint(0, 9) * 10',
    ]:
        print(line, min(timeit.repeat(line, 'from random import randrange, randint')))
```

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
