### PR TITLE
docs/requirements.txt: Specify mistune version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 Sphinx~=3.5.3
 m2r2~=0.2.7
 sphinx-rtd-theme~=0.5.1
+mistune~=0.8.4


### PR DESCRIPTION
mistune 2.x seems too new for us?

### Summary
The readthedocs build broke; see https://readthedocs.org/projects/d20/builds/18687945/ for details.

I'm hoping this might fix it, but I haven't actually tried it.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
