### PR TITLE
docs: note canonical move to personal account

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![codecov](https://codecov.io/gh/avrae/d20/branch/master/graph/badge.svg)](https://codecov.io/gh/avrae/d20)
 [![Documentation Status](https://readthedocs.org/projects/d20/badge/?version=latest)](https://d20.readthedocs.io/en/latest/start.html?badge=latest)
 
-
+> [!WARNING]
+> # The canonical repository for this project has moved to my personal account: https://github.com/zhudotexe/d20. This repository should be considered archival.
 
 
 A fast, powerful, and extensible dice engine for D&D, d20 systems, and any other system that needs dice!


### PR DESCRIPTION
### Summary
As this project is no longer maintained by D&D Beyond and the MIT license allows me to continue work on it personally, I am adopting the library under my personal account. This PR adds a note to the README redirecting any other library consumers to the new canonical repository.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
